### PR TITLE
Fix build for gcc-10 replacing some lambdas

### DIFF
--- a/llvm/lib/Transforms/Scalar/GVNHoist.cpp
+++ b/llvm/lib/Transforms/Scalar/GVNHoist.cpp
@@ -706,8 +706,15 @@ private:
       auto TI = BB->getTerminator();
       auto B = CHIs.begin();
       // [PreIt, PHIIt) form a range of CHIs which have identical VNs.
-      auto PHIIt = std::find_if(CHIs.begin(), CHIs.end(),
-                                 [B](CHIArg &A) { return A != *B; });
+
+      SmallVectorImpl<CHIArg>::iterator PHIIt = CHIs.end();
+      for (auto it = CHIs.begin(); it != CHIs.end(); ++it) {
+        if (*it != *B) {
+          PHIIt = it;
+          break;
+        }
+      }
+
       auto PrevIt = CHIs.begin();
       while (PrevIt != PHIIt) {
         // Collect values which satisfy safety checks.
@@ -728,8 +735,12 @@ private:
 
         // Check other VNs
         PrevIt = PHIIt;
-        PHIIt = std::find_if(PrevIt, CHIs.end(),
-                             [PrevIt](CHIArg &A) { return A != *PrevIt; });
+        for (auto it = PrevIt; it != CHIs.end(); ++it) {
+          if (*it != *PrevIt) {
+            PHIIt = it;
+            break;
+          }
+        }
       }
     }
   }

--- a/llvm/utils/TableGen/CodeGenSchedule.cpp
+++ b/llvm/utils/TableGen/CodeGenSchedule.cpp
@@ -371,19 +371,21 @@ processSTIPredicate(STIPredicateFunction &Fn,
                const std::pair<APInt, APInt> &LhsMasks = OpcodeMasks[LhsIdx];
                const std::pair<APInt, APInt> &RhsMasks = OpcodeMasks[RhsIdx];
 
-               auto LessThan = [](const APInt &Lhs, const APInt &Rhs) {
-                 unsigned LhsCountPopulation = Lhs.countPopulation();
-                 unsigned RhsCountPopulation = Rhs.countPopulation();
+               if (LhsMasks.first != RhsMasks.first) {
+                 unsigned LhsCountPopulation = LhsMasks.first.countPopulation();
+                 unsigned RhsCountPopulation = RhsMasks.first.countPopulation();
                  return ((LhsCountPopulation < RhsCountPopulation) ||
                          ((LhsCountPopulation == RhsCountPopulation) &&
-                          (Lhs.countLeadingZeros() > Rhs.countLeadingZeros())));
-               };
+                          (LhsMasks.first.countLeadingZeros() > RhsMasks.first.countLeadingZeros())));
+               }
 
-               if (LhsMasks.first != RhsMasks.first)
-                 return LessThan(LhsMasks.first, RhsMasks.first);
-
-               if (LhsMasks.second != RhsMasks.second)
-                 return LessThan(LhsMasks.second, RhsMasks.second);
+               if (LhsMasks.second != RhsMasks.second) {
+                 unsigned LhsCountPopulation = LhsMasks.second.countPopulation();
+                 unsigned RhsCountPopulation = RhsMasks.second.countPopulation();
+                 return ((LhsCountPopulation < RhsCountPopulation) ||
+                         ((LhsCountPopulation == RhsCountPopulation) &&
+                          (LhsMasks.second.countLeadingZeros() > RhsMasks.second.countLeadingZeros())));
+               }
 
                return LhsIdx < RhsIdx;
              });


### PR DESCRIPTION
For some reason, gcc-10 argues for this lambdas:
```
/home/alesap/code/cpp/ClickHouse/contrib/libcxx/include/type_traits: In instantiation of ‘struct std::__1::__decay<llvm::CHIArg&, true>’:
/home/alesap/code/cpp/ClickHouse/contrib/libcxx/include/type_traits:1347:94:   required from ‘struct std::__1::decay<llvm::CHIArg&&>’
/home/alesap/code/cpp/ClickHouse/contrib/libcxx/include/utility:392:16:   required by substitution of ‘template<class _Tuple, typename std::__1::enable_if<typename std::__1::conditional<(std:
:__1::__tuple_like_with_size<_Tuple, 2, typename std::__1::__uncvref<_Tp>::type>::value && (! std::__1::is_same<typename std::__1::decay<_Tp>::type, std::__1::pair<llvm::BasicBlock*, llvm::Sm
allVector<llvm::CHIArg, 2> > >::value)), std::__1::pair<llvm::BasicBlock*, llvm::SmallVector<llvm::CHIArg, 2> >::_CheckTupleLikeConstructor, std::__1::__check_tuple_constructor_fail>::type::_
_enable_implicit<_Tuple>(), bool>::type <anonymous> > std::__1::pair<llvm::BasicBlock*, llvm::SmallVector<llvm::CHIArg, 2> >::pair(_Tuple&&) [with _Tuple = llvm::CHIArg&&; typename std::__1::
enable_if<typename std::__1::conditional<(std::__1::__tuple_like_with_size<_Tuple, 2, typename std::__1::__uncvref<_Tp>::type>::value && (! std::__1::is_same<typename std::__1::decay<_Tp>::ty
pe, std::__1::pair<llvm::BasicBlock*, llvm::SmallVector<llvm::CHIArg, 2> > >::value)), std::__1::pair<llvm::BasicBlock*, llvm::SmallVector<llvm::CHIArg, 2> >::_CheckTupleLikeConstructor, std:
:__1::__check_tuple_constructor_fail>::type::__enable_implicit<_Tuple>(), bool>::type <anonymous> = <missing>]’
/home/alesap/code/cpp/ClickHouse/contrib/llvm/llvm/lib/Transforms/Scalar/GVNHoist.cpp:740:48:   required from here
/home/alesap/code/cpp/ClickHouse/contrib/libcxx/include/type_traits:1338:30: error: forming pointer to reference type ‘std::__1::remove_extent<llvm::CHIArg&>::type’ {aka ‘llvm::CHIArg&’}
 1338 |                      >::type type;
      |                              ^~~~
```
The proposed code seems to be equal.