### PR TITLE
[RFC] Add ability to keep debug symbols (depends on clickhouse option OMIT_HEAVY_DEBUG_SYMBOLS)

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -18,12 +18,11 @@ if(NOT DEFINED LLVM_VERSION_SUFFIX)
 endif()
 
 # ClickHouse specific options
-
 set (LLVM_ENABLE_PROJECTS "")
-
-add_definitions(
-    -g0             # To lower object size
-)
+if (OMIT_HEAVY_DEBUG_SYMBOLS)
+    # Lower object size
+    add_definitions(-g0)
+endif()
 
 # CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
 # New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html


### PR DESCRIPTION
This will preserve debug symbols for debug build.

Note that this will increase binary size, compressed only 85MiB (567 -> 652MiB), and decompressed ~300MiB (3.3GiB -> 3.6GiB)

Cc: @alexey-milovidov @kitaisreal 
Used in: https://github.com/ClickHouse/ClickHouse/pull/41046